### PR TITLE
Change ActiveSupport requiring

### DIFF
--- a/lib/ferryman/server.rb
+++ b/lib/ferryman/server.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'active_support/core_ext/class'
 require 'logger'
 


### PR DESCRIPTION
Начиная с `active_support` версии 4.2 обязательно сначала подключать `require 'active_support'` и только после этого отдельные части, иначе возникает ошибка.