### PR TITLE
Add require of ActiveSupport Module#delegate

### DIFF
--- a/lib/ferryman/rpc/result.rb
+++ b/lib/ferryman/rpc/result.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/module'
+
 module Ferryman
   module Rpc
     class Result


### PR DESCRIPTION
Explicit require of 'active_support/core_ext/module' necessary for usage without Rails.